### PR TITLE
Add customizable placeholders and titles to TimePicker component

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ function App() {
 |------|------|---------|-------------|
 | is24Hour | boolean | true | When true, uses 24-hour format; when false, uses 12-hour format with AM/PM selector. |
 | minuteStep | number | 5 | Controls the increment/decrement step size for minutes. Also determines the minute options shown in the dropdown (e.g., 0, 5, 10, ..., 55 for step of 5). |
+| minutePlaceholder | string | "MM" | Placeholder text for the minute input field. |
 | hourStep | number | 1 | Controls the increment/decrement step size for hours. Also determines which hour options are shown in the dropdown. |
+| hourPlaceholder | string | "HH" | Placeholder text for the hour input field. |
 | value | TimePickerValue | undefined | The controlled value for the time picker. |
 | onChange | (value: TimePickerValue) => void | undefined | Called when the time changes. |
 | label | string | undefined | Label for the time picker. |
@@ -81,6 +83,8 @@ function App() {
 | disabled | boolean | false | When true, the time picker is disabled. |
 | required | boolean | false | When true, the time picker is marked as required. |
 | classes | TimePickerClasses | {} | Custom class names for styling individual parts. |
+| popoverColumnHourTitle | string | "Hours" | Label shown above the hour list in the popover dropdown. |
+| popoverColumnMinuteTitle | string | "Minutes" | Label shown above the minute list in the popover dropdown. |
 
 ## Types
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-accessible-time-picker",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-accessible-time-picker",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-icons": "^1.3.2",

--- a/src/component/TimePicker/TimePicker.tsx
+++ b/src/component/TimePicker/TimePicker.tsx
@@ -19,6 +19,10 @@ function TimePicker({
   required,
   minuteStep = 5,
   hourStep = 1,
+  hourPlaceholder ='HH',
+  minutePlaceholder ='MM',
+  popoverColumnHourTitle ='Hours',
+  popoverColumnMinuteTitle ='Minutes',
   classes = {},
 }: TimePickerProps) {
   // Internal state for uncontrolled mode
@@ -263,7 +267,7 @@ function TimePicker({
             onChange={handleHourChange}
             onKeyDown={handleHourKeyDown}
             onBlur={handleHourBlur}
-            placeholder={"HH"}
+            placeholder={hourPlaceholder}
             className={classNames(styles.timeInput, classes.timeInput)}
             aria-label="Hour"
             id={id ? `${id}-hour` : undefined}
@@ -282,7 +286,7 @@ function TimePicker({
             onChange={handleMinuteChange}
             onKeyDown={handleMinuteKeyDown}
             onBlur={handleMinuteBlur}
-            placeholder="MM"
+            placeholder={minutePlaceholder}
             className={classNames(styles.timeInput, classes.timeInput)}
             aria-label="Minute"
             id={id ? `${id}-minute` : undefined}
@@ -421,7 +425,7 @@ function TimePicker({
                       classes.popoverColumnTitle
                     )}
                   >
-                    Hours
+                    {popoverColumnHourTitle}
                   </div>
                   <ScrollArea>
                     <div className={styles.popoverColumnContent}>
@@ -461,7 +465,7 @@ function TimePicker({
                       classes.popoverColumnTitle
                     )}
                   >
-                    Minutes
+                    {popoverColumnMinuteTitle}
                   </div>
                   <ScrollArea>
                     <div className={styles.popoverColumnContent}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,13 +30,17 @@ export type TimePickerValue = {
   is24Hour?: boolean;
   value?: TimePickerValue;
   minuteStep?: number;
+  minutePlaceholder?: string;
   hourStep?: number;
+  hourPlaceholder?: string;
   onChange?: (value: TimePickerValue) => void;
   label?: string;
   id?: string;
   disabled?: boolean;
   required?: boolean;
   classes?: TimePickerClasses;
+  popoverColumnHourTitle?: string;
+  popoverColumnMinuteTitle?: string;
 };
 
 export type { TimePickerClasses, TimePickerProps };


### PR DESCRIPTION
Make hour and minute placeholders (hourPlaceholder, minutePlaceholder) and popover column titles (popoverColumnHourTitle, popoverColumnMinuteTitle) configurable via props. Updated README and TypeScript types accordingly.